### PR TITLE
docs(tooling): add a troubleshooting entry for "autoformat on save" with ruff not working

### DIFF
--- a/docs/getting_started/installation_troubleshooting.md
+++ b/docs/getting_started/installation_troubleshooting.md
@@ -117,6 +117,25 @@ This page provides guidance on how to troubleshoot common issues that may arise 
 
     This will enable the legacy cryptographic algorithms, including RIPEMD160. See [ethereum/execution-specs#506](https://github.com/ethereum/execution-specs/issues/506) for more information.
 
+## Problem: "Autoformat on Save" with Ruff Not Working
+
+!!! danger "Problem: 'Autoformat on Save' with Ruff not working as expected in VS Code"
+    If you are using VS Code and "autoformat on save" is not working as expected, or if it produces different formatting than the official `tox -e lint` command, you may have a version mismatch with the `ruff` formatter. This problem can be confirmed if `git diff` shows changes to a file after you have saved it.
+
+    This issue often occurs when VS Code is not configured to use the project's virtual environment (`.venv`) or if the linting dependencies have not been installed. In this case, VS Code's Ruff extension falls back to a bundled version of `ruff`, which may not match the version pinned in the project's `pyproject.toml` file.
+
+!!! success "Solution: Select the correct interpreter and install all dependencies"
+
+    1.  Ensure all dependencies are installed, including the `lint` extras.
+
+        ```bash
+        uv sync --all-extras
+        ```
+
+    2.  In VS Code, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and select `Python: Select Interpreter`.
+    
+    3.  Choose the interpreter located in the project's `.venv` directory. This ensures VS Code uses the correct `ruff` version from your project's environment.
+    
 ## Other Issues Not Listed?
 
 If you're facing an issue that's not listed here, you can easily report it on GitHub for resolution.


### PR DESCRIPTION
## 🗒️ Description
This PR adds a new troubleshooting entry to `docs/getting_started/installation_troubleshooting.md` to help users resolve a common issue with the Ruff formatter in VS Code.
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes #1078

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
